### PR TITLE
Fix aggregation function bug

### DIFF
--- a/aggregate_plan.go
+++ b/aggregate_plan.go
@@ -321,7 +321,7 @@ func (a *AggregatePlan) Batch(ctx *ExecuteCtx) ([][]Column, error) {
 		}
 	}
 	if a.Limit < 0 {
-		return a.batch(nil)
+		return a.batch(ctx)
 	}
 	var (
 		rows   [][]Column
@@ -332,7 +332,7 @@ func (a *AggregatePlan) Batch(ctx *ExecuteCtx) ([][]Column, error) {
 	)
 	for a.skips < a.Start {
 		restSkips := a.Start - a.skips
-		rows, err = a.batch(nil)
+		rows, err = a.batch(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -363,7 +363,7 @@ func (a *AggregatePlan) Batch(ctx *ExecuteCtx) ([][]Column, error) {
 		return ret, nil
 	}
 	for !finish {
-		rows, err = a.batch(nil)
+		rows, err = a.batch(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/aggregate_plan.go
+++ b/aggregate_plan.go
@@ -315,7 +315,7 @@ func (a *AggregatePlan) createAggrRow(kvp KVPair, ctx *ExecuteCtx) ([]*AggrPlanF
 
 func (a *AggregatePlan) Batch(ctx *ExecuteCtx) ([][]Column, error) {
 	if !a.prepared {
-		err := a.prepareBatch(nil)
+		err := a.prepareBatch(ctx)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### Overview

This PR fixes #13 

Fix nil pointer dereference when calling aggregation functions.

### How to test

Start the REPL at `examples/memkv` and type the following query:
`select sum(value) where key ^= '' ;`

This should correctly print the result `15` instead of a nil pointer dereference error.